### PR TITLE
Add custom default theme configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ DAISY_SETTINGS = {
     'SHOW_CHANGELIST_FILTER': False,  # If True, the filter sidebar will open by default on changelist views
     'DONT_SUPPORT_ME': False, # Hide github link in sidebar footer
     'SIDEBAR_FOOTNOTE': '', # add footnote to sidebar
+    'DEFAULT_THEME': None,  # Set a default theme (e.g., 'corporate', 'dark', 'light')
+    'DEFAULT_THEME_DARK': None,  # Set a default dark theme when system prefers dark mode
+    'SHOW_THEME_SELECTOR': True,  # If False, hides the theme selector dropdown entirely
     'APPS_REORDER': {
         # Custom configurations for third-party apps that can't be modified directly in their `apps.py`
         'auth': {
@@ -141,7 +144,47 @@ DAISY_SETTINGS = {
 - **SHOW_CHANGELIST_FILTER**: Controls whether the changelist filter sidebar is shown by default.
 - **DONT_SUPPORT_ME**: Hide github link in sidebar footer.
 - **SIDEBAR_FOOTNOTE**: Add footnote to sidebar.
+- **DEFAULT_THEME**: Sets a default theme for all users (e.g., 'corporate', 'dark', 'light'). If set alone, this theme will always be used as the default regardless of system preference.
+- **DEFAULT_THEME_DARK**: Sets a default theme when the system prefers dark mode. Only used when `DEFAULT_THEME` is also set. When both are configured, the appropriate theme is chosen based on the user's system color scheme preference.
+- **SHOW_THEME_SELECTOR**: Controls whether the theme selector dropdown is visible in the navbar. Set to `False` to hide the theme selector entirely, useful when enforcing a specific theme organization-wide.
 - **APPS_REORDER**: This allows you to reorder, customize, and modify third-party apps. For example, you can change the name of the `auth` app to `users`, provide a custom icon, or hide it from the sidebar entirely.
+
+---
+
+### Theme Configuration Examples
+
+#### Single Default Theme
+To set one theme as default for all users regardless of their system preference:
+```python
+DAISY_SETTINGS = {
+    'DEFAULT_THEME': 'corporate',  # Always use corporate theme
+    # ... other settings
+}
+```
+
+#### Separate Light/Dark Default Themes
+To set different default themes based on system color scheme preference:
+```python
+DAISY_SETTINGS = {
+    'DEFAULT_THEME': 'light',       # Default for light mode
+    'DEFAULT_THEME_DARK': 'dim',    # Default for dark mode
+    # ... other settings
+}
+```
+
+#### Enforce Theme Without User Choice
+To completely hide the theme selector and enforce a specific theme:
+```python
+DAISY_SETTINGS = {
+    'DEFAULT_THEME': 'corporate',    # Enforced theme
+    'SHOW_THEME_SELECTOR': False,    # Hide theme selector
+    # ... other settings
+}
+```
+
+**Note:** The theme selection logic prioritizes user-saved preferences in localStorage first, then falls back to your configured defaults, and finally to system preference if no defaults are set.
+
+**Important:** When using custom DaisyUI themes (like 'corporate', 'dim', 'autumn', etc.) as default themes, you may need to enable `LOAD_FULL_STYLES: True` to ensure all theme styles are loaded properly.
 
 ---
 

--- a/django_daisy/module_settings.py
+++ b/django_daisy/module_settings.py
@@ -18,6 +18,9 @@ DEFAULT_DAISY_SETTINGS = {
     "SIDEBAR_FOOTNOTE": "",
     "FORM_RENDERER": "django.forms.renderers.TemplatesSetting",
     "X_FRAME_OPTIONS": "SAMEORIGIN",
+    "DEFAULT_THEME": None,
+    "DEFAULT_THEME_DARK": None,
+    "SHOW_THEME_SELECTOR": True,
     "APPS_REORDER": {
         "auth": {
             "icon": "fa-solid fa-person-military-pointing",

--- a/django_daisy/templates/admin/base.html
+++ b/django_daisy/templates/admin/base.html
@@ -28,8 +28,24 @@
             }
         }
 
+        function getDefaultTheme() {
+            const defaultTheme = '{{ DEFAULT_THEME|default:"" }}';
+            const defaultThemeDark = '{{ DEFAULT_THEME_DARK|default:"" }}';
+
+            if (defaultTheme && !defaultThemeDark) {
+                return defaultTheme; // Always use DEFAULT_THEME if dark not set
+            }
+
+            if (defaultTheme && defaultThemeDark) {
+                // Choose based on system color scheme
+                return getSystemColorScheme() === 'dark' ? defaultThemeDark : defaultTheme;
+            }
+
+            return getSystemColorScheme(); // Fall back to system preference
+        }
+
         document.documentElement.setAttribute(
-            'data-theme', localStorage.getItem('theme') || getSystemColorScheme()
+            'data-theme', localStorage.getItem('theme') || getDefaultTheme()
         )
 
         {% if change_language_url %}

--- a/django_daisy/templates/admin/parts/navbar.html
+++ b/django_daisy/templates/admin/parts/navbar.html
@@ -22,6 +22,7 @@
         </a>
     </div>
     <div class="navbar-end">
+        {% if SHOW_THEME_SELECTOR %}
         <div class="dropdown dropdown-bottom dropdown-end">
             <div tabindex="0" role="button" class="btn btn-ghost btn-sm m-1">
                 {% trans "Theme" %}
@@ -101,6 +102,7 @@
                 </li>
             </ul>
         </div>
+        {% endif %}
         <div class="dropdown dropdown-bottom dropdown-end">
             <div tabindex="0" role="button" class="btn btn-ghost btn-circle m-1">
                 <i class="fa-regular fa-user text-lg"></i>


### PR DESCRIPTION
## Summary
Implements custom default theme configuration via DAISY_SETTINGS as requested in https://github.com/hypy13/django-daisy/issues/54#issuecomment-3291586750. This allows organizations to set default themes that override system preference fallback.

## Changes
- **Add `DEFAULT_THEME` setting**: Set a single default theme for all users
- **Add `DEFAULT_THEME_DARK` setting**: Set separate default theme for dark mode preference  
- **Add `SHOW_THEME_SELECTOR` setting**: Control theme selector visibility in navbar
- **Enhanced JavaScript logic**: Smart theme selection with proper fallback hierarchy
- **Updated documentation**: Configuration examples and important notes

## Configuration Examples
```python
# Single default theme
DAISY_SETTINGS = {
    'DEFAULT_THEME': 'corporate',  # Always use corporate theme
}

# Separate light/dark defaults  
DAISY_SETTINGS = {
    'DEFAULT_THEME': 'light',       # Default for light mode
    'DEFAULT_THEME_DARK': 'dim',    # Default for dark mode  
}

# Enforce theme without user choice
DAISY_SETTINGS = {
    'DEFAULT_THEME': 'corporate',    # Enforced theme
    'SHOW_THEME_SELECTOR': False,    # Hide theme selector
}
```

## Theme Selection Logic
1. User localStorage preference (if saved)
2. Configured default theme(s) based on system preference
3. System preference (fallback - existing behavior)

## Test plan
- [x] Verify single default theme always applied
- [x] Verify dual themes chosen by system preference  
- [x] Verify theme selector visibility controlled properly
- [x] Verify backward compatibility maintained
- [x] Verify documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)